### PR TITLE
Make user enumeration by timing responses more difficult

### DIFF
--- a/lib/secure_password.ex
+++ b/lib/secure_password.ex
@@ -92,8 +92,8 @@ defmodule SecurePassword do
   @doc """
   Checks if the model password if valid.
   """
-  def authenticate(nil, _), do: false
-  def authenticate(%{password_digest: nil}, _), do: false
+  def authenticate(nil, _), do: Comeonin.Bcrypt.dummy_checkpw()
+  def authenticate(%{password_digest: nil}, _), do: Comeonin.Bcrypt.dummy_checkpw()
   def authenticate(model, nil), do: authenticate(model, "")
   def authenticate(model, password) do
     Comeonin.Bcrypt.checkpw(password, model.password_digest) && model


### PR DESCRIPTION
By simply returning false instead of generating a dummy hash, it is trivial for attackers to enumerate users by checking response time.

This is considered a security risk: http://cwe.mitre.org/data/definitions/208.html
By generating a dummy hash when the user does not exist, ecto-secure-password is _securer_. ;)

Comeonin.Bcrypt.dummy_checkpw() returns false (and this is in the contract), so all tests pass.

